### PR TITLE
improve error messaging, display optional reauthentication prompt

### DIFF
--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -46,8 +46,14 @@ class GCSBuildCacheService(val bucketName: String, val refreshAfterSeconds: Long
 
             bucket = storage.get(bucketName) ?: throw BuildCacheException("$bucketName is unavailable")
         } catch (e: IOException) {
-            throw BuildCacheException("Unable to access Google Cloud Storage bucket '$bucketName'.", e)
+            throw BuildCacheException("IOException when accessing Google Cloud Storage bucket '$bucketName'.", e)
         } catch (e: StorageException) {
+            val code = e.code
+            val message = e.message
+            System.err.println("Received error code ($code) accessing GCS: $message")
+            if (code == 401 || code == 403) {
+                System.err.println("You may need to reauthenticate with GCS")
+            }
             throw BuildCacheException("Unable to access Google Cloud Storage bucket '$bucketName'.", e)
         }
     }


### PR DESCRIPTION
This adds more useful error messaging so users can discern issues without re-invoking gradle with `--show-traces`

It also adds an optional prompt for re-authenticating if Google served a 401 or 403 response.

validation:
```
$ ./gradlew ktlintCheck

> Configure project :
WARNING: Unsupported Kotlin plugin version.
The `embedded-kotlin` and `kotlin-dsl` plugins rely on features of Kotlin `1.3.41` that might work differently than in the requested version `1.3.50`.

> Task :ktlintKotlinScriptCheck UP-TO-DATE
> Task :ktlintMainSourceSetCheck
> Task :ktlintTestSourceSetCheck NO-SOURCE
> Task :ktlintCheck

BUILD SUCCESSFUL in 1s
2 actionable tasks: 1 executed, 1 up-to-date
```