### PR TITLE
Add a hook to hanadle StorageException during cache initialization

### DIFF
--- a/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
+++ b/src/main/kotlin/net/idlestate/gradle/caching/GCSBuildCacheService.kt
@@ -48,6 +48,7 @@ class GCSBuildCacheService(val bucketName: String, val refreshAfterSeconds: Long
         } catch (e: IOException) {
             throw BuildCacheException("IOException when accessing Google Cloud Storage bucket '$bucketName'.", e)
         } catch (e: StorageException) {
+            GCSBuildCacheService.Companion.storageExceptionCallback?.invoke(e)
             val code = e.code
             var advice = ""
             if (code == 400 || code == 401 || code == 403) {
@@ -99,5 +100,10 @@ class GCSBuildCacheService(val bucketName: String, val refreshAfterSeconds: Long
 
     override fun close() {
         // nothing to do
+    }
+
+    companion object {
+        @JvmStatic
+        var storageExceptionCallback: ((StorageException) -> Unit)? = null
     }
 }


### PR DESCRIPTION
This adds a hook to allow arbitrary behavior when a StorageException is encountered, eg to automatically attempt to re-auth, or print out a custom message.